### PR TITLE
feat: initial form state

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
     "formvuelate": "^2.0.0-beta.3",
     "jest": "^26.0.1",
     "rollit": "^0.0.9",
-    "vee-validate": "^4.0.0-beta.10",
+    "vee-validate": "^4.0.0-beta.16",
     "vue": "^3.0.0-beta.12",
     "vue-jest": "^5.0.0-alpha.0",
     "yup": "^0.29.3"
   },
   "peerDependencies": {
     "formvuelate": "^2.0.0-beta.3",
-    "vee-validate": "^4.0.0-beta.10",
+    "vee-validate": "^4.0.0-beta.16",
     "vue": "^3.0.0-beta.12"
   },
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,10 @@ export default function VeeValidatePlugin(opts) {
     const { attrs: formAttrs } = getCurrentInstance();
     // Create a form context and inject the validation schema if provided
     const { handleSubmit } = useForm({
-      validationSchema: formAttrs['validation-schema'] || formAttrs['validationSchema']
+      validationSchema: formAttrs['validation-schema'] || formAttrs['validationSchema'],
+      initialErrors: formAttrs['initial-errors'] || formAttrs['initialErrors'],
+      initialDirty: formAttrs['initial-dirty'] || formAttrs['initialDirty'],
+      initialTouched: formAttrs['initial-touched'] || formAttrs['initialTouched'],
     });
 
     // Map components in schema to enhanced versions with `useField`

--- a/tests/integration/integration.spec.js
+++ b/tests/integration/integration.spec.js
@@ -16,6 +16,18 @@ const FormText = {
   props: ['label', 'modelValue', 'validation']
 }
 
+const FormTextWithMeta = {
+  template: `
+    <div>
+      <input @input="$emit('update:modelValue', $event.target.value)" />
+      <span class="dirty">{{ validation.meta.dirty }}</span>
+      <span class="touched">{{ validation.meta.touched }}</span>
+    </div>
+  `,
+  emits: ['update:modelValue'],
+  props: ['label', 'modelValue', 'validation']
+}
+
 const FormTextWithProps = {
   template: `
     <div>
@@ -235,5 +247,146 @@ describe('FVL integration', () => {
     form.trigger('submit')
     await flushPromises()
     expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('fills form errors with initial-errors attribute', async () => {
+    const schema = [
+      {
+        label: 'Email',
+        model: 'email',
+        component: FormText,
+      },
+      {
+        label: 'Password',
+        model: 'password',
+        component: FormText,
+      },
+    ]
+
+    const errors = {
+      email: 'wrong',
+      password: 'short'
+    }
+
+    const SchemaWithValidation = SchemaFormFactory([
+      veeValidatePlugin()
+    ])
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" v-model="formData" :initial-errors="errors" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup() {
+        const formData = ref({})
+
+        return {
+          schema,
+          formData,
+          errors
+        }
+      }
+    })
+
+    await flushPromises();
+    const messages = wrapper.findAll('span')
+    expect(messages[0].text()).toBe('wrong')
+    expect(messages[1].text()).toBe('short')
+  })
+
+  it('assigns the dirty meta flag using initial-dirty attribute', async () => {
+    const schema = [
+      {
+        label: 'Email',
+        model: 'email',
+        component: FormTextWithMeta,
+      },
+      {
+        label: 'Password',
+        model: 'password',
+        component: FormTextWithMeta,
+      },
+    ]
+
+    const dirty = {
+      email: true,
+      password: false
+    }
+
+    const SchemaWithValidation = SchemaFormFactory([
+      veeValidatePlugin()
+    ])
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" v-model="formData" :initial-dirty="dirty" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup() {
+        const formData = ref({})
+
+        return {
+          schema,
+          formData,
+          dirty
+        }
+      }
+    })
+
+    await flushPromises();
+    const dirtySpans = wrapper.findAll('.dirty')
+    expect(dirtySpans[0].text()).toBe('true')
+    expect(dirtySpans[1].text()).toBe('false')
+  })
+
+  it('assigns the touched meta flag using initial-touched attribute', async () => {
+    const schema = [
+      {
+        label: 'Email',
+        model: 'email',
+        component: FormTextWithMeta,
+      },
+      {
+        label: 'Password',
+        model: 'password',
+        component: FormTextWithMeta,
+      },
+    ]
+
+    const touched = {
+      email: true,
+      password: false
+    }
+
+    const SchemaWithValidation = SchemaFormFactory([
+      veeValidatePlugin()
+    ])
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" v-model="formData" :initial-touched="touched" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup() {
+        const formData = ref({})
+
+        return {
+          schema,
+          formData,
+          touched
+        }
+      }
+    })
+
+    await flushPromises();
+    const touchedSpans = wrapper.findAll('.touched')
+    expect(touchedSpans[0].text()).toBe('true')
+    expect(touchedSpans[1].text()).toBe('false')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8238,10 +8238,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vee-validate@^4.0.0-beta.10:
-  version "4.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-4.0.0-beta.13.tgz#4d5a1dcb7f2803118c7e5b92515b1503528488a2"
-  integrity sha512-3Ti3buJQKscRSwXQqop9XjfWM1vVlmF97NCXTZqclX/A9S4ZrYrllCO8E7YXicaxn9Cnhz8RyojSmyPqZp/x7Q==
+vee-validate@^4.0.0-beta.16:
+  version "4.0.0-beta.16"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-4.0.0-beta.16.tgz#561846a75b8ce86ed4df8ba837ab676c3553ec96"
+  integrity sha512-4CiQFq4MG/4XtahxC6HeggSYXxMoxQAhg/2Hw7JBtBcAkwFFQWGhnT+sZ2Y99ssmNuHgEwBpJBQHVDhbaqLVRw==
 
 vendors@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
Recently vee-validate added support for some initial form state, which helps non-SSR frameworks prefill form errors.

I added support for this feature, which reads `initialErrors`, `initialDirty`, and `initialTouched` attributes from the `SchemaForm` component if present. This is similar to `validation-schema` that's already implemented.

If accepted, I will add this to my PR to the docs as well.