### PR TITLE
upgrade to FVL v3 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "flush-promises": "^1.0.2",
-    "formvuelate": "^3.0.0-beta.7",
+    "formvuelate": "^3.0.0",
     "jest": "^26.6.3",
     "rollit": "^0.0.9",
     "vee-validate": "^4.0.0-beta.16",
@@ -44,9 +44,9 @@
     "yup": "^0.29.3"
   },
   "peerDependencies": {
-    "formvuelate": "^2.0.0-beta.3",
+    "formvuelate": "^3.0.0",
     "vee-validate": "^4.0.0-beta.16",
-    "vue": "^3.0.0-beta.12"
+    "vue": "^3.0.0"
   },
   "files": [
     "src/*",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "flush-promises": "^1.0.2",
-    "formvuelate": "^2.0.0",
+    "formvuelate": "^3.0.0-beta.7",
     "jest": "^26.6.3",
     "rollit": "^0.0.9",
     "vee-validate": "^4.0.0-beta.16",

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ export function withField (el) {
         required: true
       }
     },
-    setup(props, { attrs }) {
+    setup (props, { attrs }) {
       const { path, mapProps } = props._veeValidateConfig
       const { validations, modelValue } = toRefs(props)
       const initialValue = modelValue ? modelValue.value : undefined
@@ -137,7 +137,7 @@ export function withField (el) {
 
       const resolvedComponent = resolveDynamicComponent(Comp)
 
-      return function renderWithField() {
+      return function renderWithField () {
         return h(resolvedComponent, {
           ...props,
           ...attrs,

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,6 @@ export default function VeeValidatePlugin (opts) {
     const { handleSubmit } = useForm({
       validationSchema: formAttrs['validation-schema'] || formAttrs.validationSchema,
       initialErrors: formAttrs['initial-errors'] || formAttrs.initialErrors,
-      initialDirty: formAttrs['initial-dirty'] || formAttrs.initialDirty,
       initialTouched: formAttrs['initial-touched'] || formAttrs.initialTouched
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,6 @@ export default function VeeValidatePlugin (opts) {
       provide(VEE_VALIDATE_FVL_FORM_KEY, formContext)
     }
 
-    // Create a form context and inject the validation schema if provided
     const { handleSubmit } = formContext
 
     function mapField (el, path = '') {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { toRefs, h, computed, markRaw, watch, getCurrentInstance, unref, resolveDynamicComponent } from 'vue'
+import { toRefs, h, computed, markRaw, watch, getCurrentInstance, unref, resolveDynamicComponent, inject, provide } from 'vue'
 import { useForm, useField } from 'vee-validate'
 
 /**
@@ -19,6 +19,8 @@ function defaultMapProps (validation) {
   }
 }
 
+const VEE_VALIDATE_FVL_FORM_KEY = 'vee-validate-fvl-form-context'
+
 export default function VeeValidatePlugin (opts) {
   // Maps the validation state exposed by vee-validate to components
   const mapProps = (opts && opts.mapProps) || defaultMapProps
@@ -29,12 +31,21 @@ export default function VeeValidatePlugin (opts) {
 
     // Get additional properties not defined on the `SchemaForm` derivatives
     const { attrs: formAttrs } = getCurrentInstance()
+    // try to retrieve vee-validate form from the root schema if possible
+    let formContext = inject(VEE_VALIDATE_FVL_FORM_KEY, undefined)
+    if (!formContext) {
+      // if non-existent create one and provide it for nested schemas
+      formContext = useForm({
+        validationSchema: formAttrs['validation-schema'] || formAttrs.validationSchema,
+        initialErrors: formAttrs['initial-errors'] || formAttrs.initialErrors,
+        initialTouched: formAttrs['initial-touched'] || formAttrs.initialTouched
+      })
+
+      provide(VEE_VALIDATE_FVL_FORM_KEY, formContext)
+    }
+
     // Create a form context and inject the validation schema if provided
-    const { handleSubmit } = useForm({
-      validationSchema: formAttrs['validation-schema'] || formAttrs.validationSchema,
-      initialErrors: formAttrs['initial-errors'] || formAttrs.initialErrors,
-      initialTouched: formAttrs['initial-touched'] || formAttrs.initialTouched
-    })
+    const { handleSubmit } = formContext
 
     function mapField (el, path = '') {
       // Handles nested schemas

--- a/tests/integration/integration.spec.js
+++ b/tests/integration/integration.spec.js
@@ -294,51 +294,46 @@ describe('FVL integration', () => {
     expect(messages[1].text()).toBe('short')
   })
 
-  // it('assigns the dirty meta flag if input value was changed', async () => {
-  //   const schema = [
-  //     {
-  //       label: 'Email',
-  //       model: 'email',
-  //       component: FormTextWithMeta
-  //     },
-  //     {
-  //       label: 'Password',
-  //       model: 'password',
-  //       component: FormTextWithMeta
-  //     }
-  //   ]
+  it('assigns the dirty meta flag if input value was changed', async () => {
+    const schema = [
+      {
+        label: 'Email',
+        model: 'email',
+        component: FormTextWithMeta
+      },
+      {
+        label: 'Password',
+        model: 'password',
+        component: FormTextWithMeta
+      }
+    ]
 
-  //   const dirty = {
-  //     email: true,
-  //     password: false
-  //   }
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup () {
+        const formData = ref({})
+        useSchemaForm(formData)
 
-  //   const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
+        return {
+          schema
+        }
+      }
+    })
 
-  //   const wrapper = mount({
-  //     template: `
-  //       <SchemaWithValidation :schema="schema" :initial-dirty="dirty" />
-  //     `,
-  //     components: {
-  //       SchemaWithValidation
-  //     },
-  //     setup () {
-  //       const formData = ref({})
-  //       useSchemaForm(formData)
-
-  //       return {
-  //         schema,
-  //         formData,
-  //         dirty
-  //       }
-  //     }
-  //   })
-
-  //   await flushPromises()
-  //   const dirtySpans = wrapper.findAll('.dirty')
-  //   expect(dirtySpans[0].text()).toBe('true')
-  //   expect(dirtySpans[1].text()).toBe('false')
-  // })
+    await flushPromises()
+    const input = wrapper.findComponent(FormTextWithMeta)
+    await input.setValue('')
+    await flushPromises()
+    const dirtySpans = wrapper.findAll('.dirty')
+    expect(dirtySpans[0].text()).toBe('true')
+    expect(dirtySpans[1].text()).toBe('false')
+  })
 
   it('assigns the touched meta flag using initial-touched attribute', async () => {
     const schema = [
@@ -374,7 +369,6 @@ describe('FVL integration', () => {
 
         return {
           schema,
-          formData,
           touched
         }
       }

--- a/tests/integration/integration.spec.js
+++ b/tests/integration/integration.spec.js
@@ -1,5 +1,5 @@
 import veeValidatePlugin from '../../src/index.js'
-import { SchemaFormFactory, SchemaForm } from 'formvuelate'
+import { SchemaFormFactory, useSchemaForm } from 'formvuelate'
 import { mount } from '@vue/test-utils'
 import { markRaw, ref, computed } from 'vue'
 import * as yup from 'yup'
@@ -55,22 +55,21 @@ describe('FVL integration', () => {
       }
     }
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
 
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" />
+        <SchemaWithValidation :schema="schema" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
+
         return {
-          schema,
-          formData
+          schema
         }
       }
     })
@@ -106,16 +105,17 @@ describe('FVL integration', () => {
 
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" />
+        <SchemaWithValidation :schema="schema" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
+
         return {
-          schema,
-          formData
+          schema
         }
       }
     })
@@ -143,19 +143,19 @@ describe('FVL integration', () => {
       }
     ]
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
 
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" :validation-schema="validationSchema" />
+        <SchemaWithValidation :schema="schema" :validation-schema="validationSchema" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
+
         const validationSchema = yup.object().shape({
           email: yup.string().email(EMAIL_MESSAGE).required(),
           password: yup.string().min(4, MIN_MESSAGE).required()
@@ -202,21 +202,20 @@ describe('FVL integration', () => {
       }
     ]
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
 
     const onSubmit = jest.fn()
 
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" :validation-schema="validationSchema" @submit.prevent="onSubmit" />
+        <SchemaWithValidation :schema="schema" :validation-schema="validationSchema" @submit.prevent="onSubmit" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
         const validationSchema = yup.object().shape({
           email: yup.string().email(EMAIL_MESSAGE).required(),
           password: yup.string().min(4, MIN_MESSAGE).required()
@@ -268,19 +267,18 @@ describe('FVL integration', () => {
       password: 'short'
     }
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
 
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" :initial-errors="errors" />
+        <SchemaWithValidation :schema="schema" :initial-errors="errors" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
 
         return {
           schema,
@@ -296,52 +294,51 @@ describe('FVL integration', () => {
     expect(messages[1].text()).toBe('short')
   })
 
-  it('assigns the dirty meta flag using initial-dirty attribute', async () => {
-    const schema = [
-      {
-        label: 'Email',
-        model: 'email',
-        component: FormTextWithMeta
-      },
-      {
-        label: 'Password',
-        model: 'password',
-        component: FormTextWithMeta
-      }
-    ]
+  // it('assigns the dirty meta flag if input value was changed', async () => {
+  //   const schema = [
+  //     {
+  //       label: 'Email',
+  //       model: 'email',
+  //       component: FormTextWithMeta
+  //     },
+  //     {
+  //       label: 'Password',
+  //       model: 'password',
+  //       component: FormTextWithMeta
+  //     }
+  //   ]
 
-    const dirty = {
-      email: true,
-      password: false
-    }
+  //   const dirty = {
+  //     email: true,
+  //     password: false
+  //   }
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
+  //   const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
 
-    const wrapper = mount({
-      template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" :initial-dirty="dirty" />
-      `,
-      components: {
-        SchemaWithValidation
-      },
-      setup () {
-        const formData = ref({})
+  //   const wrapper = mount({
+  //     template: `
+  //       <SchemaWithValidation :schema="schema" :initial-dirty="dirty" />
+  //     `,
+  //     components: {
+  //       SchemaWithValidation
+  //     },
+  //     setup () {
+  //       const formData = ref({})
+  //       useSchemaForm(formData)
 
-        return {
-          schema,
-          formData,
-          dirty
-        }
-      }
-    })
+  //       return {
+  //         schema,
+  //         formData,
+  //         dirty
+  //       }
+  //     }
+  //   })
 
-    await flushPromises()
-    const dirtySpans = wrapper.findAll('.dirty')
-    expect(dirtySpans[0].text()).toBe('true')
-    expect(dirtySpans[1].text()).toBe('false')
-  })
+  //   await flushPromises()
+  //   const dirtySpans = wrapper.findAll('.dirty')
+  //   expect(dirtySpans[0].text()).toBe('true')
+  //   expect(dirtySpans[1].text()).toBe('false')
+  // })
 
   it('assigns the touched meta flag using initial-touched attribute', async () => {
     const schema = [
@@ -362,19 +359,18 @@ describe('FVL integration', () => {
       password: false
     }
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
 
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" :initial-touched="touched" />
+        <SchemaWithValidation :schema="schema" :initial-touched="touched" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
 
         return {
           schema,
@@ -400,32 +396,32 @@ describe('FVL integration', () => {
       }
     }
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
 
-    const wrapper = mount({
-
-      template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" />
+    const wrapper = mount(
+      {
+        template: `
+        <SchemaWithValidation :schema="schema" />
       `,
-      components: {
-        SchemaWithValidation
-      },
-      setup () {
-        const formData = ref({})
-        return {
-          schema,
-          formData
-        }
-      }
-    }, {
-      global: {
         components: {
-          FormText
+          SchemaWithValidation
+        },
+        setup () {
+          const formData = ref({})
+          useSchemaForm(formData)
+          return {
+            schema
+          }
+        }
+      },
+      {
+        global: {
+          components: {
+            FormText
+          }
         }
       }
-    })
+    )
 
     const input = wrapper.findComponent(FormText)
     input.setValue('')
@@ -437,9 +433,10 @@ describe('FVL integration', () => {
   })
 
   it('validates nested fields with array schema', async () => {
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
     const schema = {
       user: {
-        component: SchemaForm,
+        component: SchemaWithValidation,
         model: 'subform',
         schema: [
           {
@@ -452,22 +449,19 @@ describe('FVL integration', () => {
       }
     }
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
-
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" />
+        <SchemaWithValidation :schema="schema" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
+
         return {
-          schema,
-          formData
+          schema
         }
       }
     })
@@ -482,9 +476,10 @@ describe('FVL integration', () => {
   })
 
   it('validates nested fields with object schema', async () => {
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
     const schema = {
       user: {
-        component: SchemaForm,
+        component: SchemaWithValidation,
         model: 'subform',
         schema: {
           firstName: {
@@ -496,22 +491,19 @@ describe('FVL integration', () => {
       }
     }
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
-
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" />
+        <SchemaWithValidation :schema="schema" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
+
         return {
-          schema,
-          formData
+          schema
         }
       }
     })
@@ -527,6 +519,7 @@ describe('FVL integration', () => {
 
   it('preserves reactivity in computed schemas', async () => {
     const toggle = ref('A')
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
     const schema = computed(() => {
       if (toggle.value === 'A') {
         return {
@@ -547,23 +540,19 @@ describe('FVL integration', () => {
       }
     })
 
-    const SchemaWithValidation = SchemaFormFactory([
-      veeValidatePlugin()
-    ])
-
     const wrapper = mount({
       template: `
-        <SchemaWithValidation :schema="schema" v-model="formData" />
+        <SchemaWithValidation :schema="schema" />
       `,
       components: {
         SchemaWithValidation
       },
       setup () {
         const formData = ref({})
+        useSchemaForm(formData)
 
         return {
-          schema,
-          formData
+          schema
         }
       }
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,10 +3490,10 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formvuelate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/formvuelate/-/formvuelate-2.0.0.tgz#ab4f2557227c1b37f25b6b4e6b1f485eb8df431b"
-  integrity sha512-XH8HBUMRPmokdhy13AFBxqGTylV8211v1oNSARrn0dUGYpWUSRDcJhVVSYXMQAK9F4nQrLTTs5gV42tepC+Xsg==
+formvuelate@^3.0.0-beta.7:
+  version "3.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/formvuelate/-/formvuelate-3.0.0-beta.7.tgz#888b49be5dea5e405edc7310ae8f5539387b9629"
+  integrity sha512-mg0ZGZmTw+rLZTvaASnIWQwS+6RIn2B07pjZ1W41Kcd+7EqTLmaq/I8pMDL9/DSUZpz/ohSOa837aZw9HrsvYA==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -8272,9 +8272,9 @@ validate-npm-package-license@^3.0.1:
     spdx-expression-parse "^3.0.0"
 
 vee-validate@^4.0.0-beta.16:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-4.1.2.tgz#f7c522824775c96c4f6591034df2f8d020cbdffc"
-  integrity sha512-GKCqYxg/WqrC7NibYNgFIz50Hnw4ma9F7eA8lbi7yYdzqaHIafob7546bMuosd0yV3YnXj6gc+A2UpV1Sw3jvQ==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-4.2.2.tgz#5ef1f693af13d82b6975276a24c664765a78137d"
+  integrity sha512-YSs9YtmrdeipBLfM0xt/rvWHWqAbFe5L//baFFPPJbeMTBYBnV+YV77l8gG74xSZtpCu25o4Loyszntd6R17/w==
 
 vendors@^1.0.0:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,10 +3490,10 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formvuelate@^3.0.0-beta.7:
-  version "3.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/formvuelate/-/formvuelate-3.0.0-beta.7.tgz#888b49be5dea5e405edc7310ae8f5539387b9629"
-  integrity sha512-mg0ZGZmTw+rLZTvaASnIWQwS+6RIn2B07pjZ1W41Kcd+7EqTLmaq/I8pMDL9/DSUZpz/ohSOa837aZw9HrsvYA==
+formvuelate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/formvuelate/-/formvuelate-3.0.0.tgz#79e2bec2f3bf4f8596b789b6ea339fa405af62da"
+  integrity sha512-y12RSRgdGJdCj9qLObwyYoY2ut6dfkI8bbrDlw0ot1SLYoiLxKmDB0NZtjPm6FPDdvxHwq7lFPJuroK6XEJJbQ==
 
 fragment-cache@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This PR adapts the vee-validate plugin to the new FVL@3 API, there aren't any major changes except adding special optimization for nested schemas.

Should probably be tagged in beta along with FVL@3 releases