### PR TITLE
pass 'label' to useField options where available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,10 @@ export function withField (el) {
   const wrappedComponent = markRaw({
     name: 'withFieldWrapper',
     props: {
+      label: {
+        type: String,
+        default: undefined
+      },
       modelValue: {
         type: null,
         default: undefined
@@ -143,7 +147,7 @@ export function withField (el) {
       const { path, mapProps } = props._veeValidateConfig
       const { validations, modelValue } = toRefs(props)
       const initialValue = modelValue ? modelValue.value : undefined
-      const label = attrs.label ? attrs.label : undefined
+      const label = computed(() => props.label)
       // Build a fully qualified field name using dot notation for nested fields
       // ex: user.name
       const name = path ? `${path}.${attrs.model}` : attrs.model

--- a/src/index.js
+++ b/src/index.js
@@ -143,11 +143,13 @@ export function withField (el) {
       const { path, mapProps } = props._veeValidateConfig
       const { validations, modelValue } = toRefs(props)
       const initialValue = modelValue ? modelValue.value : undefined
+      const label = attrs.label ? attrs.label : undefined
       // Build a fully qualified field name using dot notation for nested fields
       // ex: user.name
       const name = path ? `${path}.${attrs.model}` : attrs.model
       const { value, errorMessage, meta, setTouched, errors } = useField(name, validations, {
-        initialValue
+        initialValue,
+        label
       })
 
       if (modelValue) {

--- a/tests/integration/integration.spec.js
+++ b/tests/integration/integration.spec.js
@@ -558,59 +558,6 @@ describe('FVL integration', () => {
           firstName: {
             label: 'First Name',
             component: FormText,
-            validations: yup.string().required().label('First Name')
-          }
-        }
-      }
-
-      return {
-        email: {
-          label: 'Email Address',
-          component: FormText,
-          validations: yup.string().required().label('Email Address')
-        }
-      }
-    })
-
-    const wrapper = mount({
-      template: `
-        <SchemaWithValidation :schema="schema" />
-      `,
-      components: {
-        SchemaWithValidation
-      },
-      setup () {
-        const formData = ref({})
-        useSchemaForm(formData)
-
-        return {
-          schema
-        }
-      }
-    })
-
-    let input = wrapper.findComponent(FormText)
-    input.setValue('')
-    await flushPromises()
-    expect(wrapper.find('span').text()).toMatch(/First Name/)
-
-    toggle.value = 'B'
-    await flushPromises()
-    input = wrapper.findComponent(FormText)
-    input.setValue('')
-    await flushPromises()
-    expect(wrapper.find('span').text()).toMatch(/Email Address/)
-  })
-
-  it('preserves reactivity in computed schemas with labels', async () => {
-    const toggle = ref('A')
-    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
-    const schema = computed(() => {
-      if (toggle.value === 'A') {
-        return {
-          firstName: {
-            label: 'First Name',
-            component: FormText,
             validations: yup.string().required('NAME')
           }
         }
@@ -653,6 +600,59 @@ describe('FVL integration', () => {
     input.setValue('')
     await flushPromises()
     expect(wrapper.find('span').text()).toBe('EMAIL')
+  })
+
+  it('preserves reactivity in computed schemas with labels', async () => {
+    const toggle = ref('A')
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
+    const schema = computed(() => {
+      if (toggle.value === 'A') {
+        return {
+          firstName: {
+            label: 'First Name',
+            component: FormText,
+            validations: yup.string().required().label('First Name')
+          }
+        }
+      }
+
+      return {
+        email: {
+          label: 'Email Address',
+          component: FormText,
+          validations: yup.string().required().label('Email Address')
+        }
+      }
+    })
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup () {
+        const formData = ref({})
+        useSchemaForm(formData)
+
+        return {
+          schema
+        }
+      }
+    })
+
+    let input = wrapper.findComponent(FormText)
+    input.setValue('')
+    await flushPromises()
+    expect(wrapper.find('span').text()).toMatch(/First Name/)
+
+    toggle.value = 'B'
+    await flushPromises()
+    input = wrapper.findComponent(FormText)
+    input.setValue('')
+    await flushPromises()
+    expect(wrapper.find('span').text()).toMatch(/Email Address/)
   })
 
   it('exposes form-level validation state on afterForm slot', async () => {

--- a/tests/integration/integration.spec.js
+++ b/tests/integration/integration.spec.js
@@ -114,7 +114,6 @@ describe('FVL integration', () => {
     const input = wrapper.findComponent(FormText)
     input.setValue('')
     await flushPromises()
-    console.log(wrapper.find('span').text())
     expect(wrapper.find('span').text()).toMatch(/First Name/)
     input.setValue('hello')
     await flushPromises()

--- a/tests/integration/integration.spec.js
+++ b/tests/integration/integration.spec.js
@@ -83,6 +83,44 @@ describe('FVL integration', () => {
     expect(wrapper.find('span').text()).toBe('')
   })
 
+  it('renders label in error messages', async () => {
+    const schema = {
+      firstName: {
+        label: 'First Name',
+        component: FormText,
+        validations: yup.string().required().label('First Name')
+      }
+    }
+
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup () {
+        const formData = ref({})
+        useSchemaForm(formData)
+
+        return {
+          schema
+        }
+      }
+    })
+
+    const input = wrapper.findComponent(FormText)
+    input.setValue('')
+    await flushPromises()
+    console.log(wrapper.find('span').text())
+    expect(wrapper.find('span').text()).toMatch(/First Name/)
+    input.setValue('hello')
+    await flushPromises()
+    expect(wrapper.find('span').text()).toBe('')
+  })
+
   it('maps validation state to props', async () => {
     const schema = [
       {

--- a/tests/integration/integration.spec.js
+++ b/tests/integration/integration.spec.js
@@ -558,6 +558,59 @@ describe('FVL integration', () => {
           firstName: {
             label: 'First Name',
             component: FormText,
+            validations: yup.string().required().label('First Name')
+          }
+        }
+      }
+
+      return {
+        email: {
+          label: 'Email Address',
+          component: FormText,
+          validations: yup.string().required().label('Email Address')
+        }
+      }
+    })
+
+    const wrapper = mount({
+      template: `
+        <SchemaWithValidation :schema="schema" />
+      `,
+      components: {
+        SchemaWithValidation
+      },
+      setup () {
+        const formData = ref({})
+        useSchemaForm(formData)
+
+        return {
+          schema
+        }
+      }
+    })
+
+    let input = wrapper.findComponent(FormText)
+    input.setValue('')
+    await flushPromises()
+    expect(wrapper.find('span').text()).toMatch(/First Name/)
+
+    toggle.value = 'B'
+    await flushPromises()
+    input = wrapper.findComponent(FormText)
+    input.setValue('')
+    await flushPromises()
+    expect(wrapper.find('span').text()).toMatch(/Email Address/)
+  })
+
+  it('preserves reactivity in computed schemas with labels', async () => {
+    const toggle = ref('A')
+    const SchemaWithValidation = SchemaFormFactory([veeValidatePlugin()])
+    const schema = computed(() => {
+      if (toggle.value === 'A') {
+        return {
+          firstName: {
+            label: 'First Name',
+            component: FormText,
             validations: yup.string().required('NAME')
           }
         }


### PR DESCRIPTION
I think the 'label' feature in vee-validate is worth supporting here. Otherwise, when using the built in rules, you end up with unsightly messages, such as 'first_name is not valid'.

New test added and all tests passing.

Thank you!

https://vee-validate.logaretm.com/v4/guide/i18n#custom-labels