### PR TITLE
fix: mapField does not handle array in schema array probably

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,15 +67,22 @@ export default function VeeValidatePlugin (opts) {
         }
       }
 
-      return {
-        ...el,
-        // namespaced prop to avoid clash with users' props
-        _veeValidateConfig: {
-          mapProps,
-          path
-        },
-        component: withField(el)
+      const constructField = (field) => {
+        return {
+          ...field,
+          _veeValidateConfig: {
+            mapProps,
+            path
+          },
+          component: withField(field)
+        }
       }
+
+      if (Array.isArray(el)) {
+        return el.map(constructField)
+      }
+
+      return constructField(el)
     }
 
     // Map components in schema to enhanced versions with `useField`


### PR DESCRIPTION
The PR can fix the issue that array in schema array cannot work correctly in this plugin. 
For instance, a schema like below will fail to work with the plugin:
```
[ 
  {}, 
  [ {}, {}, {} ],
  {},
]
```